### PR TITLE
Multiple kernels computing dot product [ FPGA ]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ TARGET_FLAGS = -DTARGET_$(shell echo $(or $(TARGET),default) | tr a-z A-Z)
 # - summation_method_2
 # - summation_method_3
 # - summation_method_4
+# - dot_product_method_0
 #
 # You want to specify it when invoking make as `$ TARGET_KERNEL=summation_method_0 make`
 TARGET_KERNEL_FLAGS = -D$(shell echo $(or $(TARGET_KERNEL),place_holder))

--- a/include/dot_product/method_0.hpp
+++ b/include/dot_product/method_0.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <CL/sycl.hpp>
+#include <cassert>
+
+namespace dot_product {
+sycl::event
+method_0(sycl::queue& q,
+         const sycl::uint* in_a,
+         size_t in_a_len,
+         const sycl::uint* in_b,
+         size_t in_b_len,
+         sycl::uint* const out,
+         size_t wg_size,
+         std::vector<sycl::event> evts)
+{
+  // both input vectors should have same number of elements
+  assert(in_a_len == in_b_len);
+  assert(wg_size <= in_a_len);
+  // ensure that all dispatched work-groups are of same size
+  assert(in_a_len % wg_size == 0);
+
+  return q.submit([&](sycl::handler& h) {
+    h.depends_on(evts);
+
+    h.parallel_for<class kernelDotProductMethod0>(
+      sycl::nd_range<1>{ sycl::range<1>{ in_a_len },
+                         sycl::range<1>{ wg_size } },
+      [=](sycl::nd_item<1> it) {
+        const size_t idx = it.get_global_linear_id();
+        sycl::uint tmp = *(in_a + idx) * *(in_b + idx);
+
+        // atomically update dot product stored in global memory
+        sycl::ext::oneapi::atomic_ref<
+          sycl::uint,
+          sycl::ext::oneapi::memory_order::relaxed,
+          sycl::ext::oneapi::memory_scope::device,
+          sycl::access::address_space::ext_intel_global_device_space>
+          out_ref{ *out };
+        out_ref.fetch_add(tmp);
+      });
+  });
+}
+}

--- a/include/dot_product/method_1.hpp
+++ b/include/dot_product/method_1.hpp
@@ -1,0 +1,77 @@
+#pragma once
+#include <CL/sycl.hpp>
+#include <cassert>
+
+namespace dot_product {
+sycl::event
+method_1(sycl::queue& q,
+         const sycl::uint* in_a,
+         size_t in_a_len,
+         const sycl::uint* in_b,
+         size_t in_b_len,
+         sycl::uint* const out,
+         size_t wg_size,
+         std::vector<sycl::event> evts)
+{
+  // both input vectors should have same number of elements
+  assert(in_a_len == in_b_len);
+  assert(wg_size <= in_a_len);
+  // ensure that all dispatched work-groups are of same size
+  assert(in_a_len % wg_size == 0);
+
+  return q.submit([&](sycl::handler& h) {
+    sycl::accessor<sycl::uint,
+                   1,
+                   sycl::access_mode::read_write,
+                   sycl::access::target::local>
+      scratch{ sycl::range<1>{ 1 }, h };
+    h.depends_on(evts);
+
+    h.parallel_for<class kernelDotProductMethod1>(
+      sycl::nd_range<1>{ sycl::range<1>{ in_a_len },
+                         sycl::range<1>{ wg_size } },
+      [=](sycl::nd_item<1> it) {
+        const size_t glb_idx = it.get_global_linear_id();
+        const size_t loc_idx = it.get_local_linear_id();
+        sycl::group<1> grp = it.get_group();
+
+        // only work-group leader does this
+        //
+        // initialise local memory so that atomic addition
+        // on that memory location doesn't accumulate some
+        // non-zero value
+        if (loc_idx == 0) {
+          scratch[0] = 0;
+        }
+
+        sycl::group_barrier(grp, sycl::memory_scope::work_group);
+
+        sycl::uint tmp = *(in_a + glb_idx) * *(in_b + glb_idx);
+
+        // atomically update ( work-group scope ) dot product in local memory
+        sycl::ext::oneapi::atomic_ref<
+          sycl::uint,
+          sycl::ext::oneapi::memory_order::relaxed,
+          sycl::ext::oneapi::memory_scope::work_group,
+          sycl::access::address_space::local_space>
+          scratch_ref{ scratch[0] };
+        scratch_ref.fetch_add(tmp);
+
+        sycl::group_barrier(grp, sycl::memory_scope::work_group);
+
+        // only work-group leader does this
+        if (loc_idx == 0) {
+          // atomically update work-group local dot-product
+          // in designated location in global memory
+          sycl::ext::oneapi::atomic_ref<
+            sycl::uint,
+            sycl::ext::oneapi::memory_order::relaxed,
+            sycl::ext::oneapi::memory_scope::device,
+            sycl::access::address_space::ext_intel_global_device_space>
+            out_ref{ *out };
+          out_ref.fetch_add(scratch[0]);
+        }
+      });
+  });
+}
+}

--- a/include/dot_product/method_2.hpp
+++ b/include/dot_product/method_2.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <CL/sycl.hpp>
+#include <cassert>
+
+namespace dot_product {
+sycl::event
+method_2(sycl::queue& q,
+         const sycl::uint* in_a,
+         size_t in_a_len,
+         const sycl::uint* in_b,
+         size_t in_b_len,
+         sycl::uint* const out,
+         std::vector<sycl::event> evts)
+{
+  // both input vectors should have same number of elements
+  assert(in_a_len == in_b_len);
+
+  return q.submit([&](sycl::handler& h) {
+    h.depends_on(evts);
+
+    h.single_task<class kernelDotProductMethod2>([=]() {
+      sycl::uint tmp = 0;
+      for (size_t i = 0; i < in_a_len; i++) {
+        tmp += *(in_a + i) * *(in_b + i);
+      }
+
+      *out = tmp;
+    });
+  });
+}
+}

--- a/include/dot_product/method_3.hpp
+++ b/include/dot_product/method_3.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include <CL/sycl.hpp>
+#include <cassert>
+
+namespace dot_product {
+sycl::event
+method_3(sycl::queue& q,
+         sycl::uint* in_a,
+         size_t in_a_len,
+         sycl::uint* in_b,
+         size_t in_b_len,
+         sycl::uint* const out,
+         std::vector<sycl::event> evts)
+{
+  // both input vectors should have same number of elements
+  assert(in_a_len == in_b_len);
+  // just to be sure that N -many iterations can be run, where
+  // in each iteration 4 consequtive input elements
+  // can be loaded from global memory
+  assert(in_a_len % 4 == 0);
+
+  return q.submit([&](sycl::handler& h) {
+    h.depends_on(evts);
+
+    h.single_task<class kernelDotProductMethod3>([=]() {
+      const size_t upto = in_a_len >> 2;
+
+      sycl::global_ptr<sycl::uint> in_a_ptr{ in_a };
+      sycl::global_ptr<sycl::uint> in_b_ptr{ in_b };
+
+      sycl::uint tmp = 0;
+
+      sycl::uint4 a;
+      sycl::uint4 b;
+      sycl::uint4 c;
+
+      for (size_t i = 0; i < upto; i++) {
+        a.load(i << 2, in_a_ptr);
+        b.load(i << 2, in_b_ptr);
+
+        c = a * b;
+
+        tmp += c.x() + c.y() + c.z() + c.w();
+      }
+
+      *out = tmp;
+    });
+  });
+}
+}

--- a/include/dot_product/method_3.hpp
+++ b/include/dot_product/method_3.hpp
@@ -2,6 +2,19 @@
 #include <CL/sycl.hpp>
 #include <cassert>
 
+// VECTOR_WIDTH can take value from set {2, 4, 8, 16}
+// while VECTOR_WIDTH_LOG2 will be log2(VECTOR_WIDTH)
+#define VECTOR_WIDTH 4
+#define VECTOR_WIDTH_LOG2 2
+
+#if !((VECTOR_WIDTH == 2 && VECTOR_WIDTH_LOG2 == 1) ||                         \
+      (VECTOR_WIDTH == 4 && VECTOR_WIDTH_LOG2 == 2) ||                         \
+      (VECTOR_WIDTH == 8 && VECTOR_WIDTH_LOG2 == 3) ||                         \
+      (VECTOR_WIDTH == 16 && VECTOR_WIDTH_LOG2 == 4))
+#error                                                                         \
+  "VECTOR_WIDTH can only be from {2, 4, 8, 16}, while VECTOR_WIDTH_LOG2 must be logarithm base 2 of VECTOR_WIDTH"
+#endif
+
 namespace dot_product {
 sycl::event
 method_3(sycl::queue& q,
@@ -15,24 +28,46 @@ method_3(sycl::queue& q,
   // both input vectors should have same number of elements
   assert(in_a_len == in_b_len);
   // just to be sure that N -many iterations can be run, where
-  // in each iteration 4 consequtive input elements
+  // in each iteration 2/ 4/ 8/ 16 consequtive input elements
   // can be loaded from global memory
-  assert(in_a_len % 4 == 0);
+  assert(in_a_len % VECTOR_WIDTH == 0);
 
   return q.submit([&](sycl::handler& h) {
     h.depends_on(evts);
 
     h.single_task<class kernelDotProductMethod3>([=]() {
-      const size_t upto = in_a_len >> 2;
+      const size_t upto = in_a_len >> VECTOR_WIDTH_LOG2;
 
       sycl::global_ptr<sycl::uint> in_a_ptr{ in_a };
       sycl::global_ptr<sycl::uint> in_b_ptr{ in_b };
 
       sycl::uint tmp = 0;
 
+#if VECTOR_WIDTH == 2
+#pragma message("Using vector width 2 for dot_product::method_3 kernel")
+
+      sycl::uint2 a;
+      sycl::uint2 b;
+      sycl::uint2 c;
+#elif VECTOR_WIDTH == 4
+#pragma message("Using vector width 4 for dot_product::method_3 kernel")
+
       sycl::uint4 a;
       sycl::uint4 b;
       sycl::uint4 c;
+#elif VECTOR_WIDTH == 8
+#pragma message("Using vector width 8 for dot_product::method_3 kernel")
+
+      sycl::uint8 a;
+      sycl::uint8 b;
+      sycl::uint8 c;
+#elif VECTOR_WIDTH == 16
+#pragma message("Using vector width 16 for dot_product::method_3 kernel")
+
+      sycl::uint16 a;
+      sycl::uint16 b;
+      sycl::uint16 c;
+#endif
 
       for (size_t i = 0; i < upto; i++) {
         a.load(i, in_a_ptr);
@@ -40,7 +75,18 @@ method_3(sycl::queue& q,
 
         c = a * b;
 
+#if VECTOR_WIDTH == 2
+        tmp += (c.x() + c.y());
+#elif VECTOR_WIDTH == 4
         tmp += (c.x() + c.y() + c.z() + c.w());
+#elif VECTOR_WIDTH == 8
+        tmp += (c.s0() + c.s1() + c.s2() + c.s3() + c.s4() + c.s5() + c.s6() +
+                c.s7());
+#elif VECTOR_WIDTH == 16
+        tmp += (c.s0() + c.s1() + c.s2() + c.s3() + c.s4() + c.s5() + c.s6() +
+                c.s7() + c.s8() + c.s9() + c.sA() + c.sB() + c.sC() + c.sD() +
+                c.sE() + c.sF());
+#endif
       }
 
       *out = tmp;

--- a/include/dot_product/method_3.hpp
+++ b/include/dot_product/method_3.hpp
@@ -35,12 +35,12 @@ method_3(sycl::queue& q,
       sycl::uint4 c;
 
       for (size_t i = 0; i < upto; i++) {
-        a.load(i << 2, in_a_ptr);
-        b.load(i << 2, in_b_ptr);
+        a.load(i, in_a_ptr);
+        b.load(i, in_b_ptr);
 
         c = a * b;
 
-        tmp += c.x() + c.y() + c.z() + c.w();
+        tmp += (c.x() + c.y() + c.z() + c.w());
       }
 
       *out = tmp;

--- a/include/summation.hpp
+++ b/include/summation.hpp
@@ -1,6 +1,0 @@
-#pragma once
-#include "summation/method_0.hpp"
-#include "summation/method_1.hpp"
-#include "summation/method_2.hpp"
-#include "summation/method_3.hpp"
-#include "summation/method_4.hpp"

--- a/include/test_dot_product.hpp
+++ b/include/test_dot_product.hpp
@@ -1,0 +1,81 @@
+#pragma once
+#include "utils.hpp"
+
+#if defined(dot_product_method_0)
+#include "dot_product/method_0.hpp"
+#pragma message("Compiling dot product method_0 kernel")
+#else
+#pragma message(                                                               \
+  "Specify which kernel(s) to compile, when invoking `make` utility")
+#endif
+
+namespace test_dot_product {
+
+void
+seq_dot_product(const sycl::uint* in_a,
+                size_t in_a_len,
+                const sycl::uint* in_b,
+                size_t in_b_len,
+                sycl::uint* const out)
+{
+  assert(in_a_len == in_b_len);
+
+  sycl::uint tmp = 0;
+  for (size_t i = 0; i < in_a_len; i++) {
+    tmp += *(in_a + i) * *(in_b + i);
+  }
+  *out = tmp;
+}
+
+#if defined(dot_product_method_0)
+sycl::cl_ulong
+method_0(sycl::queue& q, size_t in_len, size_t wg_size)
+{
+  sycl::uint* in_a_h =
+    static_cast<sycl::uint*>(sycl::malloc_host(sizeof(sycl::uint) * in_len, q));
+  sycl::uint* in_a_d = static_cast<sycl::uint*>(
+    sycl::malloc_device(sizeof(sycl::uint) * in_len, q));
+  sycl::uint* in_b_h =
+    static_cast<sycl::uint*>(sycl::malloc_host(sizeof(sycl::uint) * in_len, q));
+  sycl::uint* in_b_d = static_cast<sycl::uint*>(
+    sycl::malloc_device(sizeof(sycl::uint) * in_len, q));
+  sycl::uint* out_h =
+    static_cast<sycl::uint*>(sycl::malloc_host(sizeof(sycl::uint), q));
+  sycl::uint* out_d =
+    static_cast<sycl::uint*>(sycl::malloc_device(sizeof(sycl::uint), q));
+
+  random_fill(in_a_h, in_len);
+  random_fill(in_b_h, in_len);
+
+  sycl::event evt_0 = q.memcpy(in_a_d, in_a_h, sizeof(sycl::uint) * in_len);
+  sycl::event evt_1 = q.memcpy(in_b_d, in_b_h, sizeof(sycl::uint) * in_len);
+  sycl::event evt_2 = q.memset(out_d, 0, sizeof(sycl::uint));
+  sycl::event evt_3 = dot_product::method_0(
+    q, in_a_d, in_len, in_b_d, in_len, out_d, wg_size, { evt_0, evt_1, evt_2 });
+  sycl::event evt_4 = q.submit([&](sycl::handler& h) {
+    h.depends_on(evt_3);
+    h.memcpy(out_h, out_d, sizeof(sycl::uint));
+  });
+
+  evt_4.wait();
+
+  // to be asserted against it
+  sycl::uint out_cmp = 0;
+  seq_dot_product(in_a_h, in_len, in_b_h, in_len, &out_cmp);
+
+  assert(*out_h == out_cmp);
+
+  sycl::cl_ulong ts = time_event(evt_3);
+
+  sycl::free(in_a_h, q);
+  sycl::free(in_a_d, q);
+  sycl::free(in_b_h, q);
+  sycl::free(in_b_d, q);
+  sycl::free(out_h, q);
+  sycl::free(out_d, q);
+
+  return ts;
+}
+#endif
+
+}

--- a/include/test_dot_product.hpp
+++ b/include/test_dot_product.hpp
@@ -7,6 +7,9 @@
 #elif defined(dot_product_method_1)
 #include "dot_product/method_1.hpp"
 #pragma message("Compiling dot product method_1 kernel")
+#elif defined(dot_product_method_2)
+#include "dot_product/method_2.hpp"
+#pragma message("Compiling dot product method_2 kernel")
 #else
 #pragma message(                                                               \
   "Specify which kernel(s) to compile, when invoking `make` utility")
@@ -30,13 +33,16 @@ seq_dot_product(const sycl::uint* in_a,
   *out = tmp;
 }
 
-#if defined(dot_product_method_0) || defined(dot_product_method_1)
+#if defined(dot_product_method_0) || defined(dot_product_method_1) ||          \
+  defined(dot_product_method_2)
 
 sycl::cl_ulong
 #if defined(dot_product_method_0)
 method_0
 #elif defined(dot_product_method_1)
 method_1
+#elif defined(dot_product_method_2)
+method_2
 #endif
   (sycl::queue& q, size_t in_len, size_t wg_size)
 {
@@ -65,6 +71,8 @@ method_1
     method_0
 #elif defined(dot_product_method_1)
     method_1
+#elif defined(dot_product_method_2)
+    method_2
 #endif
     (q,
      in_a_d,
@@ -72,7 +80,9 @@ method_1
      in_b_d,
      in_len,
      out_d,
+#if defined(dot_product_method_0) || defined(dot_product_method_1)
      wg_size,
+#endif
      { evt_0, evt_1, evt_2 });
   sycl::event evt_4 = q.submit([&](sycl::handler& h) {
     h.depends_on(evt_3);

--- a/include/test_dot_product.hpp
+++ b/include/test_dot_product.hpp
@@ -10,6 +10,9 @@
 #elif defined(dot_product_method_2)
 #include "dot_product/method_2.hpp"
 #pragma message("Compiling dot product method_2 kernel")
+#elif defined(dot_product_method_3)
+#include "dot_product/method_3.hpp"
+#pragma message("Compiling dot product method_3 kernel")
 #else
 #pragma message(                                                               \
   "Specify which kernel(s) to compile, when invoking `make` utility")
@@ -34,7 +37,7 @@ seq_dot_product(const sycl::uint* in_a,
 }
 
 #if defined(dot_product_method_0) || defined(dot_product_method_1) ||          \
-  defined(dot_product_method_2)
+  defined(dot_product_method_2) || defined(dot_product_method_3)
 
 sycl::cl_ulong
 #if defined(dot_product_method_0)
@@ -43,6 +46,8 @@ method_0
 method_1
 #elif defined(dot_product_method_2)
 method_2
+#elif defined(dot_product_method_3)
+method_3
 #endif
   (sycl::queue& q, size_t in_len, size_t wg_size)
 {
@@ -73,6 +78,8 @@ method_2
     method_1
 #elif defined(dot_product_method_2)
     method_2
+#elif defined(dot_product_method_3)
+    method_3
 #endif
     (q,
      in_a_d,

--- a/include/test_summation.hpp
+++ b/include/test_summation.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "utils.hpp"
-#include <random>
 
 #if defined(summation_method_0)
 #include "summation/method_0.hpp"
@@ -23,18 +22,6 @@
 #endif
 
 namespace test_summation {
-void
-random_fill(sycl::uint* const in, size_t in_len)
-{
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_int_distribution<sycl::uint> dis(1u, 0xffffffffu);
-
-  for (size_t i = 0; i < in_len; i++) {
-    *(in + i) = dis(gen);
-  }
-}
-
 void
 seq_sum(const sycl::uint* in, size_t in_len, sycl::uint* const out)
 {

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <CL/sycl.hpp>
+#include <random>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 
 void
@@ -51,4 +52,16 @@ time_event(sycl::event evt)
     evt.get_profiling_info<sycl::info::event_profiling::command_end>();
 
   return (end - start);
+}
+
+void
+random_fill(sycl::uint* const in, size_t in_len)
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<sycl::uint> dis(1u, 0xffffffffu);
+
+  for (size_t i = 0; i < in_len; i++) {
+    *(in + i) = dis(gen);
+  }
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,10 +1,17 @@
-#include "test_summation.hpp"
 #include "utils.hpp"
 #include <iostream>
 
 #if defined(summation_method_0) || defined(summation_method_1) ||              \
   defined(summation_method_2) || defined(summation_method_3) ||                \
   defined(summation_method_4)
+#include "test_summation.hpp"
+#elif defined(dot_product_method_0)
+#include "test_dot_product.hpp"
+#endif
+
+#if defined(summation_method_0) || defined(summation_method_1) ||              \
+  defined(summation_method_2) || defined(summation_method_3) ||                \
+  defined(summation_method_4) || defined(dot_product_method_0)
 constexpr size_t IN_LEN = 1 << 24;
 constexpr size_t WG_SIZE = 1 << 5;
 constexpr size_t ITR_CNT = 1 << 3;
@@ -89,7 +96,22 @@ main(int argc, char** argv)
 
   std::cout << "\navg " << (double)(ts / ITR_CNT) * 1e-6 << " ms" << std::endl;
 
+#elif defined(dot_product_method_0)
+
+  sycl::cl_ulong ts = 0;
+
+  for (size_t i = 0; i < ITR_CNT; i++) {
+    sycl::cl_ulong ts_ = test_dot_product::method_0(*q, IN_LEN, WG_SIZE);
+    std::cout << "passed dot_product ( method_0 ) test\t\t"
+              << "in " << (double)ts_ * 1e-6 << " ms" << std::endl;
+
+    ts += ts_;
+  }
+
+  std::cout << "\navg " << (double)(ts / ITR_CNT) * 1e-6 << " ms" << std::endl;
+
 #else
+#pragma message("Specify which kernel(s) to compile, when invoking `make`")
   std::cout << "No kernel(s) to run !" << std::endl;
 #endif
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -5,14 +5,15 @@
   defined(summation_method_2) || defined(summation_method_3) ||                \
   defined(summation_method_4)
 #include "test_summation.hpp"
-#elif defined(dot_product_method_0) || defined(dot_product_method_1)
+#elif defined(dot_product_method_0) || defined(dot_product_method_1) ||        \
+  defined(dot_product_method_2)
 #include "test_dot_product.hpp"
 #endif
 
 #if defined(summation_method_0) || defined(summation_method_1) ||              \
   defined(summation_method_2) || defined(summation_method_3) ||                \
   defined(summation_method_4) || defined(dot_product_method_0) ||              \
-  defined(dot_product_method_1)
+  defined(dot_product_method_1) || defined(dot_product_method_2)
 constexpr size_t IN_LEN = 1 << 24;
 constexpr size_t WG_SIZE = 1 << 5;
 constexpr size_t ITR_CNT = 1 << 3;
@@ -118,6 +119,20 @@ main(int argc, char** argv)
   for (size_t i = 0; i < ITR_CNT; i++) {
     sycl::cl_ulong ts_ = test_dot_product::method_1(*q, IN_LEN, WG_SIZE);
     std::cout << "passed dot_product ( method_1 ) test\t\t"
+              << "in " << (double)ts_ * 1e-6 << " ms" << std::endl;
+
+    ts += ts_;
+  }
+
+  std::cout << "\navg " << (double)(ts / ITR_CNT) * 1e-6 << " ms" << std::endl;
+
+#elif defined(dot_product_method_2)
+
+  sycl::cl_ulong ts = 0;
+
+  for (size_t i = 0; i < ITR_CNT; i++) {
+    sycl::cl_ulong ts_ = test_dot_product::method_2(*q, IN_LEN, WG_SIZE);
+    std::cout << "passed dot_product ( method_2 ) test\t\t"
               << "in " << (double)ts_ * 1e-6 << " ms" << std::endl;
 
     ts += ts_;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -5,13 +5,14 @@
   defined(summation_method_2) || defined(summation_method_3) ||                \
   defined(summation_method_4)
 #include "test_summation.hpp"
-#elif defined(dot_product_method_0)
+#elif defined(dot_product_method_0) || defined(dot_product_method_1)
 #include "test_dot_product.hpp"
 #endif
 
 #if defined(summation_method_0) || defined(summation_method_1) ||              \
   defined(summation_method_2) || defined(summation_method_3) ||                \
-  defined(summation_method_4) || defined(dot_product_method_0)
+  defined(summation_method_4) || defined(dot_product_method_0) ||              \
+  defined(dot_product_method_1)
 constexpr size_t IN_LEN = 1 << 24;
 constexpr size_t WG_SIZE = 1 << 5;
 constexpr size_t ITR_CNT = 1 << 3;
@@ -103,6 +104,20 @@ main(int argc, char** argv)
   for (size_t i = 0; i < ITR_CNT; i++) {
     sycl::cl_ulong ts_ = test_dot_product::method_0(*q, IN_LEN, WG_SIZE);
     std::cout << "passed dot_product ( method_0 ) test\t\t"
+              << "in " << (double)ts_ * 1e-6 << " ms" << std::endl;
+
+    ts += ts_;
+  }
+
+  std::cout << "\navg " << (double)(ts / ITR_CNT) * 1e-6 << " ms" << std::endl;
+
+#elif defined(dot_product_method_1)
+
+  sycl::cl_ulong ts = 0;
+
+  for (size_t i = 0; i < ITR_CNT; i++) {
+    sycl::cl_ulong ts_ = test_dot_product::method_1(*q, IN_LEN, WG_SIZE);
+    std::cout << "passed dot_product ( method_1 ) test\t\t"
               << "in " << (double)ts_ * 1e-6 << " ms" << std::endl;
 
     ts += ts_;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -6,14 +6,15 @@
   defined(summation_method_4)
 #include "test_summation.hpp"
 #elif defined(dot_product_method_0) || defined(dot_product_method_1) ||        \
-  defined(dot_product_method_2)
+  defined(dot_product_method_2) || defined(dot_product_method_3)
 #include "test_dot_product.hpp"
 #endif
 
 #if defined(summation_method_0) || defined(summation_method_1) ||              \
   defined(summation_method_2) || defined(summation_method_3) ||                \
   defined(summation_method_4) || defined(dot_product_method_0) ||              \
-  defined(dot_product_method_1) || defined(dot_product_method_2)
+  defined(dot_product_method_1) || defined(dot_product_method_2) ||            \
+  defined(dot_product_method_3)
 constexpr size_t IN_LEN = 1 << 24;
 constexpr size_t WG_SIZE = 1 << 5;
 constexpr size_t ITR_CNT = 1 << 3;
@@ -133,6 +134,20 @@ main(int argc, char** argv)
   for (size_t i = 0; i < ITR_CNT; i++) {
     sycl::cl_ulong ts_ = test_dot_product::method_2(*q, IN_LEN, WG_SIZE);
     std::cout << "passed dot_product ( method_2 ) test\t\t"
+              << "in " << (double)ts_ * 1e-6 << " ms" << std::endl;
+
+    ts += ts_;
+  }
+
+  std::cout << "\navg " << (double)(ts / ITR_CNT) * 1e-6 << " ms" << std::endl;
+
+#elif defined(dot_product_method_3)
+
+  sycl::cl_ulong ts = 0;
+
+  for (size_t i = 0; i < ITR_CNT; i++) {
+    sycl::cl_ulong ts_ = test_dot_product::method_3(*q, IN_LEN, WG_SIZE);
+    std::cout << "passed dot_product ( method_3 ) test\t\t"
               << "in " << (double)ts_ * 1e-6 << " ms" << std::endl;
 
     ts += ts_;

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# just to be safe !
+make clean
+
+# summation
+TARGET=cpu TARGET_KERNEL=summation_method_0 make; make clean
+TARGET=cpu TARGET_KERNEL=summation_method_1 make; make clean
+TARGET=cpu TARGET_KERNEL=summation_method_2 make; make clean
+TARGET=cpu TARGET_KERNEL=summation_method_3 make; make clean
+TARGET=cpu TARGET_KERNEL=summation_method_4 make; make clean
+
+# dot product
+TARGET=cpu TARGET_KERNEL=dot_product_method_0 make; make clean

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -13,3 +13,4 @@ TARGET=cpu TARGET_KERNEL=summation_method_4 make; make clean
 # dot product
 TARGET=cpu TARGET_KERNEL=dot_product_method_0 make; make clean
 TARGET=cpu TARGET_KERNEL=dot_product_method_1 make; make clean
+TARGET=cpu TARGET_KERNEL=dot_product_method_2 make; make clean

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -12,3 +12,4 @@ TARGET=cpu TARGET_KERNEL=summation_method_4 make; make clean
 
 # dot product
 TARGET=cpu TARGET_KERNEL=dot_product_method_0 make; make clean
+TARGET=cpu TARGET_KERNEL=dot_product_method_1 make; make clean

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -14,3 +14,4 @@ TARGET=cpu TARGET_KERNEL=summation_method_4 make; make clean
 TARGET=cpu TARGET_KERNEL=dot_product_method_0 make; make clean
 TARGET=cpu TARGET_KERNEL=dot_product_method_1 make; make clean
 TARGET=cpu TARGET_KERNEL=dot_product_method_2 make; make clean
+TARGET=cpu TARGET_KERNEL=dot_product_method_3 make; make clean


### PR DESCRIPTION
I've written multiple ( competing ) kernels for computing dot product of two large vectors ( say of length 2^24 ), all targeted to be executed on  Intel PAC.

- Multiple Work Item -based design using global atomic operation 
- Multiple Work Item -based design using both global/ local atomic operation 
- Single Work Item -based design using loop unrolling 
- Single Work Item -based design using SYCL vector intrinsics ( using `sycl::uint{2,4,8,16}` )